### PR TITLE
Correct installation location of HiddenFunctions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.rst
-include high_dimensional_sampling/hidden_functions/*.bin
+include high_dimensional_sampling/hidden_functions/16.04/*.bin
+include high_dimensional_sampling/hidden_functions/18.04/*.bin


### PR DESCRIPTION
HiddenFunctions were not installed at the correct location when installing the package using `pip`. This pull request fixes this by altering the MANIFEST.in file.